### PR TITLE
Loose requirements versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,9 @@ exec(open(join(dirname(__file__),
 PACKAGE = 'robotframework-jenkins'
 DESCRIPTION = '''Library for Robot Framework for Jenkins interaction'''
 REQUIREMENTS = [
-    'python-jenkins==1.*',
-    'robotframework==3.*',
-    'requests==2.*'
+    'python-jenkins>=1.*',
+    'robotframework>=3.*',
+    'requests>=2.*'
 ]
 
 with open('README.md') as f:


### PR DESCRIPTION
There was already a pull request regarding the loosement of requirements versions: https://github.com/okgolove/robotframework-jenkins/pull/13
Is it possible to loose them a bit more?